### PR TITLE
feat: AEMET Service Integration, Data Normalization, and Risk Engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,4 @@ logs/
 
 # Sistema operativo
 .DS_Store
-Thumbs.db
+Thumbs.db.agent_docs/

--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,4 @@ logs/
 
 # Sistema operativo
 .DS_Store
-Thumbs.db.agent_docs/
+Thumbs.db

--- a/config/municipios.json
+++ b/config/municipios.json
@@ -1,0 +1,7 @@
+{
+    "3195": "Madrid (Retiro)",
+    "3100B": "Aranjuez",
+    "2462": "Navacerrada",
+    "3100": "Alcalá de Henares",
+    "3200": "Getafe / Alcorcón"
+}

--- a/services/alert_service.py
+++ b/services/alert_service.py
@@ -1,0 +1,51 @@
+from typing import Dict, Any, List
+
+try:
+    from utils.validators import validate_weather_data
+except ImportError:
+    # Placeholder for development if utils.validators is not yet fully implemented
+    print("WARNING: Could not import 'validate_weather_data' from 'utils.validators'. Using a dummy validator.")
+    def validate_weather_data(data: Dict[str, Any]) -> bool:
+        # Dummy implementation: always return True for now, assuming valid data for alert processing
+        return True
+
+class AlertService:
+    """Motor de análisis de riesgos climáticos y generación de alertas."""
+
+    def evaluar_alertas(self, registro_normalizado: Dict[str, Any]) -> List[str]:
+        """
+        Analiza un registro y genera alertas basadas en umbrales técnicos.
+        
+        Args:
+            registro_normalizado (Dict[str, Any]): Registro tras el proceso de normalización.
+            
+        Returns:
+            List[str]: Lista de etiquetas de alerta activas.
+        """
+        # 1. Validación previa obligatoria
+        if not validate_weather_data(registro_normalizado):
+            return []
+
+        alertas = []
+        temp = registro_normalizado.get("temperatura", 0.0)
+        viento = registro_normalizado.get("viento", 0.0)
+        lluvia = registro_normalizado.get("lluvia", 0.0)
+        humedad = registro_normalizado.get("humedad", 0)
+
+        # 2. Lógica de Temperatura (Jerarquía Excluyente)
+        if temp >= 40.0:  # Umbral Crítico Calor
+            alertas.append("ROJA")
+        elif temp >= 35.0:  # Umbral Advertencia Calor
+            alertas.append("NARANJA")
+        elif temp <= 0.0:  # Umbral Helada
+            alertas.append("HELADA")
+
+        # 3. Lógica Independiente (Acumulativa)
+        if viento > 70.0:
+            alertas.append("VIENTO_FUERTE")
+        if lluvia > 30.0:
+            alertas.append("LLUVIA_INTENSA")
+        if humedad >= 90:
+            alertas.append("HUMEDAD_ALTA")
+
+        return alertas

--- a/services/alert_service.py
+++ b/services/alert_service.py
@@ -1,10 +1,12 @@
+import logging
 from typing import Dict, Any, List
 
 try:
     from utils.validators import validate_weather_data
 except ImportError:
     # Placeholder for development if utils.validators is not yet fully implemented
-    print("WARNING: Could not import 'validate_weather_data' from 'utils.validators'. Using a dummy validator.")
+    logger = logging.getLogger(__name__)
+    logger.warning("Could not import 'validate_weather_data' from 'utils.validators'. Using a dummy validator.")
     def validate_weather_data(data: Dict[str, Any]) -> bool:
         # Dummy implementation: always return True for now, assuming valid data for alert processing
         return True

--- a/services/normalizer_service.py
+++ b/services/normalizer_service.py
@@ -1,0 +1,68 @@
+import json
+import os
+from typing import Dict, Any
+
+class NormalizerService:
+    """
+    Servicio para la normalización de datos al Contrato de Adriana.
+    
+    Campos: fecha, municipio, codigo_municipio, temperatura, humedad, viento, lluvia, fuente, alertas.
+    """
+
+    def __init__(self, municipios_path: str = "config/municipios.json"):
+        self.municipios_map = self._load_municipios(municipios_path)
+
+    def _load_municipios(self, path: str) -> Dict[str, str]:
+        """Carga el mapeo oficial de IDs y nombres de municipios."""
+        try:
+            with open(path, 'r', encoding='utf-8') as f:
+                return json.load(f)
+        except (FileNotFoundError, json.JSONDecodeError):
+            # Logica de fallback mínima por seguridad si el archivo falta
+            return {}
+
+    def _parse_float(self, value: Any) -> float:
+        """
+        Convierte valores a float manejando casos nulos e 'Ip' (Inapreciable).
+        """
+        if value is None:
+            return 0.0
+        
+        if isinstance(value, str):
+            if value.strip().lower() == "ip":
+                return 0.0
+            try:
+                return float(value.replace(',', '.'))
+            except ValueError:
+                return 0.0
+                
+        return float(value)
+
+    def normalizar_respuesta_aemet(self, datos_crudos: Dict[str, Any], station_id: str) -> Dict[str, Any]:
+        """
+        Transforma el JSON de AEMET al formato estándar de Climapp.
+        
+        Args:
+            datos_crudos (Dict[str, Any]): Datos directos de la API.
+            station_id (str): Identificador de la estación.
+            
+        Returns:
+            Dict[str, Any]: Diccionario bajo el contrato de datos oficial.
+        """
+        # Formateo de fecha: AEMET (fint) '2023-10-27T10:00:00' -> 'YYYY-MM-DD HH:mm:ss'
+        fecha_iso = datos_crudos.get("fint", "")
+        # Limpiamos la T y los posibles desfases de zona horaria para cumplir el contrato
+        fecha_formateada = fecha_iso.replace('T', ' ').split('+')[0] if fecha_iso else "N/A"
+
+        # Mapeo de campos según contrato Adriana
+        return {
+            "fecha": fecha_formateada,
+            "municipio": self.municipios_map.get(station_id, "Municipio Desconocido"),
+            "codigo_municipio": station_id,
+            "temperatura": self._parse_float(datos_crudos.get("ta")),
+            "humedad": int(self._parse_float(datos_crudos.get("hr"))),
+            "viento": self._parse_float(datos_crudos.get("vv")),
+            "lluvia": self._parse_float(datos_crudos.get("prec")),
+            "fuente": "api_aemet",
+            "alertas": []
+        }

--- a/services/normalizer_service.py
+++ b/services/normalizer_service.py
@@ -1,5 +1,4 @@
 import json
-import os
 from typing import Dict, Any
 
 class NormalizerService:

--- a/services/retry_service.py
+++ b/services/retry_service.py
@@ -1,0 +1,27 @@
+import logging
+from requests import Session
+from urllib3.util.retry import Retry
+from requests.adapters import HTTPAdapter
+
+def get_retry_session(retries: int = 3, backoff_factor: float = 1.5) -> Session:
+    """
+    Configura una sesión de requests con reintentos automáticos para errores transitorios.
+    
+    Args:
+        retries (int): Número total de reintentos permitidos.
+        backoff_factor (float): Factor de espera exponencial (ej. 1.5s, 3s, 4.5s...).
+        
+    Returns:
+        Session: Objeto sesión de requests configurado con la estrategia de Retry.
+    """
+    session = Session()
+    retry_strategy = Retry(
+        total=retries,
+        backoff_factor=backoff_factor,
+        status_forcelist=[429, 500, 502, 503, 504],
+        allowed_methods=["GET"]
+    )
+    adapter = HTTPAdapter(max_retries=retry_strategy)
+    session.mount("https://", adapter)
+    session.mount("http://", adapter)
+    return session

--- a/services/weather_api_service.py
+++ b/services/weather_api_service.py
@@ -1,0 +1,74 @@
+import os
+import requests
+import logging
+from typing import Dict, Any, Optional
+from dotenv import load_dotenv
+from services.retry_service import get_retry_session
+
+load_dotenv()
+
+class WeatherAPIService:
+    """Servicio para la integración con AEMET OpenData siguiendo el flujo de dos pasos."""
+
+    def __init__(self):
+        self.api_key = os.getenv("AEMET_API_KEY")
+        self.base_url = "https://opendata.aemet.es/opendata/api/observacion/convencional/datos/estacion/"
+        self.logger = logging.getLogger(__name__)
+        self.session = get_retry_session()
+        
+        # IDs de Estación validados según directiva de Madrid
+        self.estaciones_validas = ["3195", "3100B", "2462", "3100", "3200"]
+
+    def fetch_station_data(self, station_id: str) -> Optional[Dict[str, Any]]:
+        """
+        Ejecuta el flujo de dos pasos para obtener datos de una estación.
+        
+        Args:
+            station_id (str): ID de la estación meteorológica.
+            
+        Returns:
+            Optional[Dict[str, Any]]: El registro más reciente o None en caso de error.
+        """
+        if not self.api_key:
+            self.logger.error("AEMET_API_KEY no configurada.")
+            return None
+
+        url_paso_1 = f"{self.base_url}{station_id}"
+        headers = {
+            'cache-control': "no-cache",
+            'api_key': self.api_key
+        }
+
+        try:
+            # Paso 1: Petición de URL de descarga
+            response_1 = self.session.get(url_paso_1, headers=headers, timeout=15)
+            response_1.raise_for_status()
+            
+            meta_res = response_1.json()
+            if meta_res.get("estado") != 200:
+                self.logger.warning(f"AEMET respondió con error: {meta_res.get('descripcion')}")
+                return None
+
+            url_datos = meta_res.get("datos")
+            
+            # Paso 2: Descarga de datos reales
+            response_2 = self.session.get(url_datos, timeout=15)
+            response_2.raise_for_status()
+            
+            datos = response_2.json()
+            
+            # Retornamos la observación más reciente (última en la lista de AEMET)
+            if isinstance(datos, list) and len(datos) > 0:
+                return datos[-1]
+            
+            return None
+
+        except requests.exceptions.RequestException as e:
+            self.logger.error(f"Error de conexión con AEMET (Estación {station_id}): {e}")
+            return None
+        except (ValueError, KeyError) as e:
+            self.logger.error(f"Error procesando formato de respuesta AEMET: {e}")
+            return None
+        except Exception as e:
+            self.logger.error(f"Error inesperado en WeatherAPIService: {e}")
+            return None

--- a/services/weather_api_service.py
+++ b/services/weather_api_service.py
@@ -1,4 +1,5 @@
 import os
+import json
 import requests
 import logging
 from typing import Dict, Any, Optional
@@ -10,14 +11,24 @@ load_dotenv()
 class WeatherAPIService:
     """Servicio para la integración con AEMET OpenData siguiendo el flujo de dos pasos."""
 
-    def __init__(self):
+    def __init__(self, municipios_path: str = "config/municipios.json"):
         self.api_key = os.getenv("AEMET_API_KEY")
         self.base_url = "https://opendata.aemet.es/opendata/api/observacion/convencional/datos/estacion/"
         self.logger = logging.getLogger(__name__)
         self.session = get_retry_session()
         
-        # IDs de Estación validados según directiva de Madrid
-        self.estaciones_validas = ["3195", "3100B", "2462", "3100", "3200"]
+        # Cargamos las estaciones válidas desde la configuración oficial para evitar hardcoding
+        self.estaciones_validas = self._load_valid_stations(municipios_path)
+
+    def _load_valid_stations(self, path: str) -> list:
+        """Carga los IDs de las estaciones desde el archivo de configuración."""
+        try:
+            with open(path, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+                return list(data.keys())
+        except (FileNotFoundError, json.JSONDecodeError) as e:
+            self.logger.error(f"Error cargando municipios en WeatherAPIService: {e}")
+            return ["3195", "3100B", "2462", "3100", "3200"]  # Fallback de seguridad
 
     def fetch_station_data(self, station_id: str) -> Optional[Dict[str, Any]]:
         """

--- a/services/weather_api_service.py
+++ b/services/weather_api_service.py
@@ -33,6 +33,11 @@ class WeatherAPIService:
             self.logger.error("AEMET_API_KEY no configurada.")
             return None
 
+        # Validación preventiva de ID de estación
+        if station_id not in self.estaciones_validas:
+            self.logger.warning(f"ID de estación no reconocido: {station_id}")
+            return None
+
         url_paso_1 = f"{self.base_url}{station_id}"
         headers = {
             'cache-control': "no-cache",

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,0 +1,37 @@
+import pytest
+from services.normalizer_service import NormalizerService
+from services.alert_service import AlertService
+
+def test_normalizer_handles_ip_rain():
+    """Verifica que la lluvia inapreciable 'Ip' se convierta en 0.0."""
+    service = NormalizerService()
+    raw_data = {"fint": "2023-10-27T10:00:00", "prec": "Ip", "ta": "20", "hr": "50", "vv": "10"}
+    normalized = service.normalizar_respuesta_aemet(raw_data, "3195")
+    assert normalized["lluvia"] == 0.0
+    assert isinstance(normalized["lluvia"], float)
+
+def test_alert_service_red_alert():
+    """Verifica que se dispare la alerta ROJA a partir de 40 grados."""
+    service = AlertService()
+    data = {
+        "temperatura": 42.0,
+        "viento": 10.0,
+        "lluvia": 0.0,
+        "humedad": 40
+    }
+    alertas = service.evaluar_alertas(data)
+    assert "ROJA" in alertas
+
+def test_alert_service_multiple_alerts():
+    """Verifica que las alertas sean acumulativas (viento y lluvia)."""
+    service = AlertService()
+    data = {
+        "temperatura": 20.0,
+        "viento": 80.0,
+        "lluvia": 45.0,
+        "humedad": 50
+    }
+    alertas = service.evaluar_alertas(data)
+    assert "VIENTO_FUERTE" in alertas
+    assert "LLUVIA_INTENSA" in alertas
+    assert len(alertas) == 2


### PR DESCRIPTION
This PR implements the core service layer for climate data retrieval and processing (Persona 3 - Juan).

🚀 Key Changes:
AEMET Integration (weather_api_service.py): Implemented the mandatory two-step API flow, including proactive validation for Madrid station IDs.

Resilience (retry_service.py): Added a retry mechanism with Exponential Backoff to handle network errors and rate limiting (429 Too Many Requests).

Data Normalization (normalizer_service.py): Full transformation to match Adriana's Data Contract. Includes "Ip" rain data cleaning to 0.0 and strict type casting (float for measurements, int for humidity).

Alert Engine (alert_service.py): Logic for climate risks (Red, Orange, Frost, and cumulative alerts).

🤝 Collaboration & Handover:
@Adriana (Scrum Master): The service layer is now fully compatible with the official contract. Stations are mapped dynamically via config/municipios.json. You can now safely integrate WeatherAPIService into the main api_controller.py.

@Elena (Persona 4): I've implemented a temporary dummy validator in AlertService using a try-except block. This ensures the system remains testable for everyone until your official utils/validators.py is ready. We can swap the import once you push your changes.

@Isabela (Persona 2): The normalized data output is now strictly formatted as we agreed, ensuring seamless integration with the manual registration flow.

🛠️ Technical Notes:
Local test scripts (test_persona3.py) and sensitive configurations (.env) are correctly excluded via .gitignore.

Validated with real-time AEMET data for Madrid stations.

Ready for review and merge into main